### PR TITLE
DEV: Resolve `component.get` deprecation by modernising connector

### DIFF
--- a/assets/javascripts/discourse/connectors/discovery-list-container-top/password-expiry-warning.hbs
+++ b/assets/javascripts/discourse/connectors/discovery-list-container-top/password-expiry-warning.hbs
@@ -1,1 +1,3 @@
-{{password-expiry-warning}}
+{{#if this.currentUser.password_expiry_warning}}
+  <PasswordExpiryWarning />
+{{/if}}

--- a/assets/javascripts/discourse/connectors/discovery-list-container-top/password-expiry-warning.js
+++ b/assets/javascripts/discourse/connectors/discovery-list-container-top/password-expiry-warning.js
@@ -1,23 +1,6 @@
-export default {
-  shouldRender(args, component) {
-    return !!component.get("currentUser.password_expiry_warning");
-  },
+import Component from "@glimmer/component";
+import { inject as service } from "@ember/service";
 
-  setupComponent(args, component) {
-    component.set(
-      "daysLeft",
-      Math.ceil(
-        moment(component.get("currentUser.password_expires_at")).diff(
-          moment(),
-          "days",
-          true
-        )
-      )
-    );
-
-    component.set(
-      "expired",
-      moment().isAfter(moment(component.get("currentUser.password_expires_at")))
-    );
-  },
-};
+export default class extends Component {
+  @service currentUser;
+}


### PR DESCRIPTION
The two properties being set weren't even being used, so we can just delete them